### PR TITLE
Hotfix, make it possible to flash bricked Cubes (already in a bootloader and not in Ardupilot)

### DIFF
--- a/dv/scripts/flash_ardupilot.sh
+++ b/dv/scripts/flash_ardupilot.sh
@@ -4,11 +4,11 @@ set -ex
 
 PORT=/dev/ttyTHS1
 
-./dv/scripts/wait_online.py "${PORT}"
-./dv/scripts/reboot_autopilot.py "${PORT}"
-./dv/scripts/wait_online.py "${PORT}"
+# ./dv/scripts/wait_online.py "${PORT}"
+# ./dv/scripts/reboot_autopilot.py "${PORT}"
+# ./dv/scripts/wait_online.py "${PORT}"
 
-python3 ./Tools/scripts/uploader.py --port "${PORT}" --baud-flightstack 921600,500000,115200,57600  --baud-bootloader 115200 --identify
+# python3 ./Tools/scripts/uploader.py --port "${PORT}" --baud-flightstack 921600,500000,115200,57600  --baud-bootloader 115200 --identify
 python3 ./Tools/scripts/uploader.py --port "${PORT}" --baud-flightstack 921600,500000,115200,57600  --baud-bootloader 115200 ./build/CubeOrangePlus-dv/bin/arducopter.apj
 
 ./dv/scripts/wait_online.py "${PORT}"

--- a/dv/scripts/flash_ardupilot.sh
+++ b/dv/scripts/flash_ardupilot.sh
@@ -4,7 +4,7 @@ set -ex
 
 PORT=/dev/ttyTHS1
 
-python3 ./Tools/scripts/uploader.py --port "${PORT}" --baud-flightstack 921600,500000,115200,57600  --baud-bootloader 115200 ./build/CubeOrangePlus-dv/bin/arducopter.apj
+python3 ./Tools/scripts/uploader.py --port "${PORT}" --baud-flightstack 921600,115200,57600  --baud-bootloader 115200 ./build/CubeOrangePlus-dv/bin/arducopter.apj
 
 ./dv/scripts/wait_online.py "${PORT}"
 ./dv/scripts/request_flash_bootloader.py "${PORT}"

--- a/dv/scripts/flash_ardupilot.sh
+++ b/dv/scripts/flash_ardupilot.sh
@@ -4,11 +4,6 @@ set -ex
 
 PORT=/dev/ttyTHS1
 
-# ./dv/scripts/wait_online.py "${PORT}"
-# ./dv/scripts/reboot_autopilot.py "${PORT}"
-# ./dv/scripts/wait_online.py "${PORT}"
-
-# python3 ./Tools/scripts/uploader.py --port "${PORT}" --baud-flightstack 921600,500000,115200,57600  --baud-bootloader 115200 --identify
 python3 ./Tools/scripts/uploader.py --port "${PORT}" --baud-flightstack 921600,500000,115200,57600  --baud-bootloader 115200 ./build/CubeOrangePlus-dv/bin/arducopter.apj
 
 ./dv/scripts/wait_online.py "${PORT}"

--- a/dv/scripts/utils.py
+++ b/dv/scripts/utils.py
@@ -59,7 +59,7 @@ def get_tcp_master(connection='tcp:127.0.0.1:5760'):
     return some_master
 
 
-def get_serial_master(lport, bauds=(921600, 115200, 57600, 1500000)):
+def get_serial_master(lport, bauds=(921600, 115200, 57600)):
     for baud_flightstack in bauds:
         logger.info(f"Probing autopilot at {lport}:{baud_flightstack}")
         some_master = mavutil.mavlink_connection(lport, baud=baud_flightstack)

--- a/dv/scripts/utils.py
+++ b/dv/scripts/utils.py
@@ -59,7 +59,7 @@ def get_tcp_master(connection='tcp:127.0.0.1:5760'):
     return some_master
 
 
-def get_serial_master(lport, bauds=(921600, 115200, 57600)):
+def get_serial_master(lport, bauds=(1500000, 921600, 115200, 57600)):
     for baud_flightstack in bauds:
         logger.info(f"Probing autopilot at {lport}:{baud_flightstack}")
         some_master = mavutil.mavlink_connection(lport, baud=baud_flightstack)

--- a/dv/scripts/utils.py
+++ b/dv/scripts/utils.py
@@ -59,7 +59,7 @@ def get_tcp_master(connection='tcp:127.0.0.1:5760'):
     return some_master
 
 
-def get_serial_master(lport, bauds=(1500000, 921600, 115200, 57600)):
+def get_serial_master(lport, bauds=(921600, 115200, 57600, 1500000)):
     for baud_flightstack in bauds:
         logger.info(f"Probing autopilot at {lport}:{baud_flightstack}")
         some_master = mavutil.mavlink_connection(lport, baud=baud_flightstack)


### PR DESCRIPTION
1. Make it possible to flash bricked Cubes (already in a bootloader and not in Ardupilot). When something went wrong with the previous flash, for example.

Previously it was a wrong assumption that a reboot just before flashing could help with the flashing issues, but it was false.